### PR TITLE
Removed use of alternative “not” operator.

### DIFF
--- a/fsm.h
+++ b/fsm.h
@@ -336,7 +336,7 @@ public:
 			err_code = Fsm_Success;
 
 			// Check if guard exists and returns true.
-			if(transition.guard && (not transition.guard())) continue;
+			if(transition.guard && !transition.guard()) continue;
 
 			// Now we have to take the action and set the new state.
 			// Then we are done.


### PR DESCRIPTION
The alternative boolean tokens aren't well supported in Visual Studio, requiring either to compile without extensions ("/Za") or to include the <ciso646> header, which implements them as macros, which wreaks havoc with inline asm.