### PR TITLE
declare transitions in constructor

### DIFF
--- a/fsm.h
+++ b/fsm.h
@@ -237,6 +237,26 @@ public:
 	{
 	}
 
+	template <typename InputIt>
+	Fsm(InputIt start, InputIt end) :
+		m_transitions(), m_cs(Initial), m_debug_fn(nullptr)
+	{
+		add_transitions(start, end);
+	}
+
+	template <typename Coll>
+	Fsm(Coll &&c) :
+		m_transitions(), m_cs(Initial), m_debug_fn(nullptr)
+	{
+		add_transitions(c);
+	}
+
+	Fsm(std::initializer_list<Trans>&& i) :
+		m_transitions(), m_cs(Initial), m_debug_fn(nullptr)
+	{
+		add_transitions(i);
+	}
+
 	/**
 	 * Sets the current state to the given state. Defaults to the Initial state.
 	 *

--- a/tests/fsm_test.cpp
+++ b/tests/fsm_test.cpp
@@ -244,6 +244,47 @@ TEST_CASE("Test single argument add_transitions function")
 	}
 }
 
+TEST_CASE("Test single argument constructors with transitions")
+{
+	enum class States { Initial, A, Final };
+	using F = FSM::Fsm<States, States::Initial, char>;
+
+	SECTION("Test raw array")
+	{
+		F::Trans v[] = {
+			{States::Initial, States::A, 'a', nullptr, nullptr},
+			{States::A, States::Final, 'b', nullptr, nullptr},
+		};
+		F fsm(&v[0], &v[2]);
+		fsm.execute('a');
+		fsm.execute('b');
+		REQUIRE(fsm.state() == States::Final);
+	}
+
+	SECTION("Test vector")
+	{
+		std::vector<F::Trans> v = {
+			{States::Initial, States::A, 'a', nullptr, nullptr},
+			{States::A, States::Final, 'b', nullptr, nullptr},
+		};
+		F fsm(v);
+		fsm.execute('a');
+		fsm.execute('b');
+		REQUIRE(fsm.state() == States::Final);
+	}
+
+	SECTION("Test initializer list")
+	{
+		F fsm{
+			{States::Initial, States::A, 'a', nullptr, nullptr},
+			{States::A, States::Final, 'b', nullptr, nullptr},
+		};
+		fsm.execute('a');
+		fsm.execute('b');
+		REQUIRE(fsm.state() == States::Final);
+	}
+}
+
 TEST_CASE("Test int as type for states")
 {
 	int INITIAL = 1;


### PR DESCRIPTION
mirroring the `add_transitions` functions behaviors in constructor you can declare a FMS with all needed information in a single line (e.g. member initializer list)