### PR TITLE
Move error code changing below guard check.

### DIFF
--- a/fsm.h
+++ b/fsm.h
@@ -335,11 +335,11 @@ public:
 
 			// Check if trigger matches.
 			if(trigger != transition.trigger) continue;
-			err_code = Fsm_Success;
 
 			// Check if guard exists and returns true.
 			if(transition.guard && !transition.guard()) continue;
-
+			err_code = Fsm_Success;
+			
 			// Now we have to take the action and set the new state.
 			// Then we are done.
 


### PR DESCRIPTION
I thought that it isn't correct to return `Fsm_Success` when the action wasn't executed and the state hasn't changed. 

I'd make this method without `err_code` var:
```C++
	Fsm_Errors execute(Trigger trigger)
	{
		const auto state_transitions = m_transitions.find(m_cs);
		if(state_transitions == m_transitions.end()) {
			return Fsm_NoMatchingTrigger; // No transition from current state found.
		}

		// iterate the transitions
		const transition_elem_t& active_transitions = state_transitions->second;
		for(const auto& transition : active_transitions) {
			// Check if trigger matches.
			if(trigger != transition.trigger) continue;
			// Check if guard exists and returns true.
			if(transition.guard && !transition.guard()) continue;
			
			// Now we have to take the action and set the new state.
			// Then we are done.

			// Check if action exists and execute it.
			if(transition.action != 0) {
				transition.action(); // execute action
			}
			m_cs = transition.to_state;
			if(m_debug_fn) {
				m_debug_fn(transition.from_state, transition.to_state, trigger);
			}
			return Fsm_Success;
		}

		return Fsm_NoMatchingTrigger;
	}
```